### PR TITLE
Feat: add team random generation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lru_redux (1.1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -181,7 +182,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    shadcn-ui (0.0.5)
+    shadcn-ui (0.0.12)
+      tailwind_merge (~> 0.7)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -192,6 +194,8 @@ GEM
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     stringio (3.0.8)
+    tailwind_merge (0.7.4)
+      lru_redux (~> 1.1)
     tailwindcss-rails (2.0.30-arm64-darwin)
       railties (>= 6.0.0)
     thor (1.2.2)
@@ -247,4 +251,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.2.22
+   2.4.19

--- a/app/controllers/random_teams_controller.rb
+++ b/app/controllers/random_teams_controller.rb
@@ -1,0 +1,27 @@
+class RandomTeamsController < ApplicationController
+  def index
+    @random_team = RandomTeam.new(players_per_team: 7, list: session[:list])
+  end
+
+  def create
+    @random_team = RandomTeam.new(random_team_params)
+    session[:list] = @random_team.list
+
+    if @random_team.missing_players.any?
+      flash.now[:error] = 'Missing players in the list.'
+
+      render :index, status: :unprocessable_entity
+    else
+      @random_team.generate!
+      flash.now[:success] = 'Random teams were successfully created.'
+
+      render :index,  status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def random_team_params
+    params.require(:random_team).permit(:list, :players_per_team)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,16 @@
 module ApplicationHelper
+  def flash_class(type)
+    case type
+    when 'success'
+      'bg-green-50 text-green-500'
+    when 'error'
+      'bg-red-50 text-red-500 '
+    when 'alert'
+      'bg-yellow-50 text-yellow-500'
+    when 'notice'
+      'bg-blue-500 text-white'
+    else
+      'bg-gray-500 text-white'
+    end
+  end
 end

--- a/app/models/random_team.rb
+++ b/app/models/random_team.rb
@@ -1,0 +1,49 @@
+class RandomTeam
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  MAX_GENERATION_ATTEMPTS = 1_000
+
+  attribute :list, :string
+  attribute :players_per_team, :integer, default: 7
+  attribute :teams, default: []
+
+  validates :list, presence: true
+  validates :players_per_team, presence: true
+
+  def missing_players
+    player_names = players.map { |player| player.name.downcase }
+    player_names_from_list.reject { |name| player_names.include?(name) }
+  end
+
+  def generate!
+    MAX_GENERATION_ATTEMPTS.times do |i|
+      possible_teams = players.shuffle.each_slice(players_per_team).to_a
+      possible_teams_weights = possible_teams.map { |team| team_weight(team) }
+      diff_team_weight = possible_teams_weights.max - possible_teams_weights.min
+
+      if diff_team_weight <= 2
+        self.teams = possible_teams
+        return
+      end
+    end
+  end
+
+  def players
+    @players ||= Player.where('LOWER(name) IN (?)', player_names_from_list)
+  end
+
+  private
+
+  def player_names_from_list
+    list.split("\n")
+      .map(&:strip)
+      .reject(&:empty?)
+      .map { |line| line.gsub(/^\d+\.\s*/, '') }
+      .map(&:downcase)
+  end
+
+  def team_weight(team)
+    team.reduce(0) { |sum, player| sum + player.level }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,8 @@
     <%= render "shared/header" %>
 
     <main class="container mx-auto mt-12 px-5">
+      <%= render 'shared/flash_messages' %>
+
       <%= yield %>
     </main>
   </body>

--- a/app/views/random_teams/index.html.erb
+++ b/app/views/random_teams/index.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="form-group">
-        <%= form.text_area :list, rows: 22, class: "form-control max-w-[340px] w-full" %>
+        <%= form.text_area :list, class: "form-control max-w-[340px] w-full min-h-[360px]" %>
       </div>
       <%= form.submit "Generate", class: "mt-4 inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-10 px-4 py-2   bg-primary text-primary-foreground hover:bg-primary/90" %>
     <% end %>
@@ -27,7 +27,7 @@
       <% @random_team.teams.each_with_index do |team, index| %>
         <div>
           <h3 class='font-semibold mb-1' style="color: <%= colors[index] %>">
-            Team <%= index %>
+            Team <%= index + 1 %> - <span class='font-normal'><%= team.sum(&:level) %></span>
           </h3>
           <ol class='ml-4' style='list-style: decimal'>
             <% team.sort_by(&:level).reverse.each do |player| %>

--- a/app/views/random_teams/index.html.erb
+++ b/app/views/random_teams/index.html.erb
@@ -1,0 +1,51 @@
+<div class="w-full">
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-2xl my-8">Create random team</h1>
+  </div>
+
+  <div class="grid grid-cols-2 gap-5">
+    <%= form_with(model: @random_team,  url: random_teams_path, method: :post) do |form| %>
+      <div class="form-group mb-4">
+        <%= form.number_field :players_per_team, class: "form-control max-w-[340px] w-full", placeholder: 'Player per team' %>
+      </div>
+
+      <div class="form-group">
+        <%= form.text_area :list, rows: 22, class: "form-control max-w-[340px] w-full" %>
+      </div>
+      <%= form.submit "Generate", class: "mt-4 inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-10 px-4 py-2   bg-primary text-primary-foreground hover:bg-primary/90" %>
+    <% end %>
+
+    <div>
+      <%# TODO: future ui with selects %>
+    </div>
+  </div>
+
+  <% if @random_team.teams.any? %>
+    <% colors = ["#FFB84C", "#98D8AA", "#393646", "tomato"]  %>
+
+    <div class='grid grid-cols-3 gap-5 mt-6'>
+      <% @random_team.teams.each_with_index do |team, index| %>
+        <div>
+          <h3 class='font-semibold mb-1' style="color: <%= colors[index] %>">
+            Team <%= index %>
+          </h3>
+          <ol class='ml-4' style='list-style: decimal'>
+            <% team.sort_by(&:level).reverse.each do |player| %>
+              <li><%= player.name %> - <%= player.level %></li>
+            <% end %>
+          </ol>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if @random_team.missing_players.any? %>
+    <div class="mt-6">
+      <h3 class="font-semibold mb-1">Missing players</h3>
+      <ul>
+        <% @random_team.missing_players.each do |player| %>
+          <li><%= player %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,9 @@
+<% if flash.any? %>
+  <div class="max-w-[600px]">
+    <% flash.each do |type, message| %>
+      <div class="<%= flash_class(type) %> py-2 px-3 font-medium rounded-lg inline-block w-full" role="alert">
+        <%= message %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,6 +13,7 @@
       <nav class="flex items-center space-x-6 text-sm font-medium">
         <a class="transition-colors hover:text-foreground/80  text-foreground/60" href="/">Home</a>
         <a class="transition-colors hover:text-foreground/80 text-foreground/60 text-foreground/60" href="/players">Players</a>
+        <a class="transition-colors hover:text-foreground/80 text-foreground/60 text-foreground/60" href="/random_teams">Create team</a>
       </nav>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   root 'home#index'
 
   resources :players
+  resources :random_teams, only: %i[index create]
 end

--- a/test/models/random_team_test.rb
+++ b/test/models/random_team_test.rb
@@ -1,0 +1,47 @@
+# test/models/random_team_test.rb
+
+require 'test_helper'
+
+class RandomTeamTest < ActiveSupport::TestCase
+  def setup
+    @player1 = Player.create(name: 'Frank', level: 2)
+    @player2 = Player.create(name: 'Sandrito', level: 2)
+    @player3 = Player.create(name: 'Davis', level: 4)
+    @player4 = Player.create(name: 'Vladi', level: 4)
+
+    @list = """
+      1. Frank
+      2. Sandrito
+      3. Davis
+      4. Vladi
+    """
+  end
+
+  test 'generate teams successfully with existing players' do
+    random_team = RandomTeam.new(list: @list, players_per_team: 2)
+
+    assert_equal 0, random_team.missing_players.size
+
+    random_team.generate!
+
+    assert_equal 2, random_team.teams.size
+    [@player1, @player2, @player3, @player4].each do |player|
+      assert_includes random_team.players, player
+    end
+  end
+
+
+  test 'identify missing players before generating teams' do
+    @list = """
+      1. Frank
+      2. Sandrito
+      3. Davis
+      4. Spectre
+    """
+
+    random_team = RandomTeam.new(list: @list, players_per_team: 2)
+
+    assert_includes random_team.missing_players, 'spectre'
+    assert_equal 0, random_team.teams.size
+  end
+end


### PR DESCRIPTION
This PR introduces a new feature for generating random teams with custom player distribution. Users can now specify the number of players per team, allowing for flexible team configurations. Additionally, this feature includes player validation, alerting users when a player from the input list is not found in the database.

<img width="1793" alt="Screen Shot 2023-09-11 at 11 46 28" src="https://github.com/condef5/m11/assets/21107031/832f92d9-f658-41bb-9000-215f779ed12c">

<hr />

<img width="1795" alt="Screen Shot 2023-09-11 at 11 49 34" src="https://github.com/condef5/m11/assets/21107031/0de73ba3-ed1b-4f36-9bef-380a80236d30">

